### PR TITLE
fix(endpoints): fix issues with chat completions endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openai-responses"
-version = "0.1.0"
+version = "0.1.1"
 description = "Automatically mock OpenAI requests"
 authors = ["Michael Harris <mharris@definite.app>"]
 license = "MIT"

--- a/src/openai_responses/endpoints/_base.py
+++ b/src/openai_responses/endpoints/_base.py
@@ -40,9 +40,10 @@ class StatelessMock(Mock):
     ):
         def decorator(fn: Callable[..., Any]):
             is_async = inspect.iscoroutinefunction(fn)
-            argspec = inspect.getfullargspec(fn)
+            argspec = inspect.getfullargspec(unwrap(fn))
             needs_ref = mocker_class in argspec.args
 
+            @wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any):
                 if needs_ref:
                     kwargs[mocker_class] = self
@@ -52,6 +53,7 @@ class StatelessMock(Mock):
                     sort_routes(respx.mock.routes._routes)
                     return await fn(*args, **kwargs)
 
+            @wraps(fn)
             def wrapper(*args: Any, **kwargs: Any):
                 if needs_ref:
                     kwargs[mocker_class] = self
@@ -75,7 +77,6 @@ class StatefulMock(Mock):
         state_store: StateStore,
     ):
         def decorator(fn: Callable[..., Any]):
-
             is_async = inspect.iscoroutinefunction(fn)
             argspec = inspect.getfullargspec(unwrap(fn))
             needs_ref = mocker_class in argspec.args

--- a/src/openai_responses/endpoints/chat.py
+++ b/src/openai_responses/endpoints/chat.py
@@ -134,6 +134,7 @@ class ChatCompletionMock(StatelessMock):
                             type="function",
                         )
                     )
+                return calls
 
         message = ChatCompletionMessage(
             content=p.get("message", {}).get("content"),


### PR DESCRIPTION
Fixes issues for:

- Stateless mocks need to also use functools wraps to pass all arguments through from Pytest
- Tool calls were always being returned as none from the chat completions endpoint