### PR TITLE
feat(endpoints): refactor base mock class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ bug: lorem ipsum
 
 ## Requesting a feature
 
-The main goal of this project is to provide automatic mocking for *all* of the OpenAI API endpoints. If an endpoint or specific feature/behavior of an endpoint is currently not supported, chances are that it's already on the [roadmap](#roadmap). If you don't find the feature you need already in the issues please add a new issue and prefix the title with `feat:` and add the <span style='background-color: blue; padding: 2px; border-radius: 5px'>enhancement</span> label.
+The main goal of this project is to provide automatic mocking for _all_ of the OpenAI API endpoints. If an endpoint or specific feature/behavior of an endpoint is currently not supported, chances are that it's already on the [roadmap](#roadmap). If you don't find the feature you need already in the issues please add a new issue and prefix the title with `feat:` and add the <span style='background-color: blue; padding: 2px; border-radius: 5px'>enhancement</span> label.
 
 Example title:
 
@@ -26,23 +26,23 @@ feat: lorem ipsum
 
 The roadmap is just a ranking of the currently open issues and no hard dates are set at this point for any fix or new feature.
 
-I (Michael) am the BDFL of the project and can and will arbitrarily rank issues according to my own needs (and those of my [employer](https://www.definite.app)) but for the most part I try to evaluate priority of issues based on a 2-dimensional system that looks at ***effort*** and ***impact***.
+I (Michael) am the BDFL of the project and can and will arbitrarily rank issues according to my own needs (and those of my [employer](https://www.definite.app)) but for the most part I try to evaluate priority of issues based on a 2-dimensional system that looks at **_effort_** and **_impact_**.
 
-- *Effort* is a rough estimate of whether something will take a lot of work, some work, or little work to implement
-- *Impact* is a rough estimate of how important something is
+- _Effort_ is a rough estimate of whether something will take a lot of work, some work, or little work to implement
+- _Impact_ is a rough estimate of how important something is
 
 Both are unscientific flawed but they allow me to try to focus on maximizing impact while minimizing effort which is important for an open source project.
 
 If you look at the [project's issues](https://github.com/mharrisb1/openai-responses-python/issues), you'll see they are labeled with some non-standard labels.
 
-| Label                                                                                | Description   |
-| ------------------------------------------------------------------------------------ | ------------- |
-| <span style='background-color: green; padding: 2px; border-radius: 5px'>e0 🌵</span>  | Low effort    |
+| Label                                                                                  | Description   |
+| -------------------------------------------------------------------------------------- | ------------- |
+| <span style='background-color: green; padding: 2px; border-radius: 5px'>e0 🌵</span>   | Low effort    |
 | <span style='background-color: yellow; padding: 2px; border-radius: 5px'>e1 ⚡️</span> | Medium effort |
-| <span style='background-color: red; padding: 2px; border-radius: 5px'>e2 🔥</span>    | High effort   |
-| <span style='background-color: green; padding: 2px; border-radius: 5px'>i0 🌵</span>  | Low impact    |
+| <span style='background-color: red; padding: 2px; border-radius: 5px'>e2 🔥</span>     | High effort   |
+| <span style='background-color: green; padding: 2px; border-radius: 5px'>i0 🌵</span>   | Low impact    |
 | <span style='background-color: yellow; padding: 2px; border-radius: 5px'>i1 ⚡️</span> | Medium impact |
-| <span style='background-color: red; padding: 2px; border-radius: 5px'>i2 🔥</span>    | High impact   |
+| <span style='background-color: red; padding: 2px; border-radius: 5px'>i2 🔥</span>     | High impact   |
 
 Ranking is evaluated according to this quadrant where the priority is ordered from top to bottom and left to right.
 
@@ -71,7 +71,7 @@ pipx install poetry==1.8                    # if not already installed
 poetry config virtualenvs.in-project true   # recommended
 poetry install --with dev                   # install deps including development deps
 poetry shell                                # activate venv
-tox run                                     # run static analysis, unit tests, and examples
+tox run                                     # run lint, static analysis, unit tests, and examples
 ```
 
 ## Design Overview
@@ -80,7 +80,7 @@ tox run                                     # run static analysis, unit tests, a
 
 Mocks are classes that are responsible for encapsulating all request patching of a given endpoint.
 
-Endpoints are classified as either *stateless* or *stateful* mocks. Right now, the only difference between `StatelessMock` and `StatefulMock` is the injection of `used_state` (see [state store](#state-store) below for more).
+Endpoints are classified as either _stateless_ or _stateful_ mocks. Right now, the only difference between `StatelessMock` and `StatefulMock` is the injection of `used_state` (see [state store](#state-store) below for more).
 
 ```mermaid
 classDiagram

--- a/src/openai_responses/endpoints/_base.py
+++ b/src/openai_responses/endpoints/_base.py
@@ -1,7 +1,6 @@
 import inspect
-from functools import wraps
-from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Protocol
+from functools import partial, wraps
+from typing import Any, Callable, Dict, List, Optional, Protocol, TypedDict
 
 import httpx
 import respx
@@ -13,54 +12,104 @@ from ..state import StateStore
 
 
 class KwargsGetterProtocol(Protocol):
-    def __call__(self, *args: Any, **kwargs: Any) -> Dict[str, Any]: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        ...
 
 
-class Mock(ABC):
-    BASE_URL = "https://api.openai.com/v1"
-
-    def __init__(self) -> None:
-        _fake = Faker()
-        _fake.add_provider(OpenAiApiProvider)
-        self._faker: OpenAiApiProvider.Api = _fake.openai()
-
-    @abstractmethod
-    def _register_routes(self, **common: Any) -> None: ...
+class RouteRegistration(TypedDict):
+    name: str
+    method: Callable[..., respx.Route]
+    pattern: Optional[str]
+    side_effect: Callable[..., httpx.Response]
 
 
-def sort_routes(routes: List[respx.Route]) -> None:
-    routes.sort(key=lambda r: len(repr(r._pattern)), reverse=True)  # type: ignore
+class Mock:
+    def __init__(
+        self,
+        *,
+        name: str,
+        endpoint: Optional[str] = None,
+        route_registrations: Optional[List[RouteRegistration]] = None,
+    ) -> None:
+        print("Mocker initialized")
+        self._name = name
+        self._base_url = "https://api.openai.com"
+        self._endpoint = endpoint or ""
+        self._registrations = route_registrations or []
+
+        fake = Faker()
+        fake.add_provider(OpenAiApiProvider)
+        self._faker: OpenAiApiProvider.Api = fake.openai()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def set_base_url(self, url: str) -> None:
+        self._base_url = url
+
+    @property
+    def endpoint(self) -> str:
+        return self._endpoint
+
+    @property
+    def url(self) -> str:
+        return self._base_url + self._endpoint
+
+    @staticmethod
+    def _sort_routes(routes: List[respx.Route]) -> None:
+        routes.sort(key=lambda r: len(repr(r._pattern)), reverse=True)  # type: ignore
+
+    def _register_routes(self, **kwargs: Any) -> None:
+        for registration in self._registrations:
+            setattr(
+                self,
+                registration["name"],
+                CallContainer(
+                    route=registration["method"](
+                        url__regex=self.url + (registration["pattern"] or "")
+                    ).mock(
+                        side_effect=partial(
+                            registration["side_effect"],
+                            **kwargs,
+                        )
+                    )
+                ),
+            )
 
 
 class StatelessMock(Mock):
     def _make_decorator(
         self,
-        mocker_class: str,
         common_kwargs_getter: KwargsGetterProtocol,
     ):
         def decorator(fn: Callable[..., Any]):
             is_async = inspect.iscoroutinefunction(fn)
             argspec = inspect.getfullargspec(unwrap(fn))
-            needs_ref = mocker_class in argspec.args
+            needs_ref = self._name in argspec.args
 
             @wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any):
                 if needs_ref:
-                    kwargs[mocker_class] = self
+                    kwargs[self.name] = self
                 common_kwargs = common_kwargs_getter(*args, **kwargs)
                 with respx.mock:
                     self._register_routes(**common_kwargs)
-                    sort_routes(respx.mock.routes._routes)
+                    self._sort_routes(respx.mock.routes._routes)
                     return await fn(*args, **kwargs)
 
             @wraps(fn)
             def wrapper(*args: Any, **kwargs: Any):
                 if needs_ref:
-                    kwargs[mocker_class] = self
+                    kwargs[self.name] = self
                 common_kwargs = common_kwargs_getter(*args, **kwargs)
                 with respx.mock:
                     self._register_routes(**common_kwargs)
-                    sort_routes(respx.mock.routes._routes)
+                    self._sort_routes(respx.mock.routes._routes)
                     return fn(*args, **kwargs)
 
             return wrapper if not is_async else async_wrapper
@@ -69,38 +118,36 @@ class StatelessMock(Mock):
 
 
 class StatefulMock(Mock):
-
     def _make_decorator(
         self,
-        mocker_class: str,
         common_kwargs_getter: KwargsGetterProtocol,
         state_store: StateStore,
     ):
         def decorator(fn: Callable[..., Any]):
             is_async = inspect.iscoroutinefunction(fn)
             argspec = inspect.getfullargspec(unwrap(fn))
-            needs_ref = mocker_class in argspec.args
+            needs_ref = self._name in argspec.args
 
             @wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any):
                 if needs_ref:
-                    kwargs[mocker_class] = self
+                    kwargs[self.name] = self
                 state = kwargs.get("state_store", state_store)
                 common_kwargs = common_kwargs_getter(used_state=state, *args, **kwargs)
                 with respx.mock:
                     self._register_routes(**common_kwargs)
-                    sort_routes(respx.mock.routes._routes)
+                    self._sort_routes(respx.mock.routes._routes)
                     return await fn(*args, **kwargs)
 
             @wraps(fn)
             def wrapper(*args: Any, **kwargs: Any):
                 if needs_ref:
-                    kwargs[mocker_class] = self
+                    kwargs[self.name] = self
                 state = kwargs.get("state_store", state_store)
                 common_kwargs = common_kwargs_getter(used_state=state, *args, **kwargs)
                 with respx.mock:
                     self._register_routes(**common_kwargs)
-                    sort_routes(respx.mock.routes._routes)
+                    self._sort_routes(respx.mock.routes._routes)
                     return fn(*args, **kwargs)
 
             return wrapper if not is_async else async_wrapper
@@ -109,7 +156,5 @@ class StatefulMock(Mock):
 
 
 class CallContainer:
-    def __init__(self) -> None:
-        self.route = respx.Route()
-        self.request: Optional[httpx.Request] = None
-        self.response: Optional[httpx.Response] = None
+    def __init__(self, route: Optional[respx.Route] = None) -> None:
+        self.route = route or respx.Route()

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -7,7 +7,7 @@ import respx
 from openai_responses.decorators import side_effect, unwrap
 
 
-def test_side_effect_make_decorator():
+def test_side_effect():
     @side_effect
     def wrapped_side_effect(route: respx.Route, **kwargs: Any) -> httpx.Response:
         return httpx.Response(status_code=200)

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,21 @@
 [tox]
 skipdist = true
-envlist = static, unit, examples
+envlist = lint, static, unit, examples
 
 [testenv]
 allowlist_externals =
     black
     pytest
     mypy
-	
-[testenv:static]
-commands =
+
+[testenv:lint]
+command =
     black src
     black tests
 	black examples
+
+[testenv:static]
+commands =
     mypy src
 	mypy tests
 	mypy examples


### PR DESCRIPTION
Cleans up the base `Mock` class, particularly around route registration to avoid a decent bit of code duplication.
