### PR TITLE
feat(api): expose RESPX router as property

### DIFF
--- a/docs/user_guide/external.md
+++ b/docs/user_guide/external.md
@@ -1,0 +1,23 @@
+# External APIs
+
+Since this project is powered by [RESPX](https://lundberg.github.io/respx), all API calls to HTTPX or HTTP Core will be patched. If a route is not mocked, then this will result in an error.
+
+For example, if you're calling to external APIs for [function calling](https://platform.openai.com/docs/assistants/tools/function-calling) and your testing these function calls with this project, then you will need to add a custom mock for that route.
+
+A [respx.Router](https://lundberg.github.io/respx/api/#router) instance is exposed from the main `OpenAIMock` object. This allows you to use the interface provided by RESPX to define your own mock.
+
+```python linenums="1"
+openai_mock.router.post(url="https://api.myweatherapi.com").mock(
+    Response(200, json={"value": "57"})
+)
+```
+
+See full example [here](https://github.com/mharrisb1/openai-responses-python/blob/35-featapi-expose-router-as-prop/examples/test_router_usage.py) or view RESPX mocking docs [here](https://lundberg.github.io/respx/guide/#mocking-responses).
+
+## Pass Through
+
+If you want a call to not be mocked and actually be sent to an external service, then you can use RESPX's [pass through](https://lundberg.github.io/respx/guide/#pass-through) feature.
+
+```python linenums="1"
+openai_mock.router.post(url="https://api.myweatherapi.com").pass_through()
+```

--- a/examples/test_context_manager.py
+++ b/examples/test_context_manager.py
@@ -1,0 +1,34 @@
+import openai
+
+from openai_responses import OpenAIMock
+
+
+def test_create_chat_completion():
+    openai_mock = OpenAIMock()
+
+    with openai_mock.router:
+        openai_mock.chat.completions.create.response = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "content": "Hello! How can I help?",
+                        "role": "assistant",
+                    },
+                }
+            ]
+        }
+
+        client = openai.Client(api_key="sk-fake123")
+        completion = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"},
+            ],
+        )
+
+        assert len(completion.choices) == 1
+        assert completion.choices[0].message.content == "Hello! How can I help?"
+        assert openai_mock.chat.completions.create.calls.call_count == 1

--- a/examples/test_router_usage.py
+++ b/examples/test_router_usage.py
@@ -1,0 +1,148 @@
+import json
+from typing import Any
+
+import httpx
+import openai
+from openai.types.beta.threads.run_submit_tool_outputs_params import ToolOutput
+
+import openai_responses
+from openai_responses import OpenAIMock, Request, Response, Route, StateStore
+from openai_responses.helpers.mergers.runs import merge_run_with_partial
+
+
+def polled_get_run_responses(
+    request: Request,
+    route: Route,
+    state_store: StateStore,
+    **kwargs: Any,
+) -> Response:
+    # RESPX will inject `id` (for run ID) and `thread_id` into the kwargs
+    run_id = kwargs["id"]
+    run = state_store.beta.threads.runs.get(run_id)
+    assert run
+    if route.call_count < 4:
+        run.status = "in_progress"
+        state_store.beta.threads.runs.put(run)
+        return Response(200, request=request, json=run.model_dump())
+
+    else:
+        run = merge_run_with_partial(
+            run,
+            {
+                "status": "requires_action",
+                "required_action": {
+                    "type": "submit_tool_outputs",
+                    "submit_tool_outputs": {
+                        "tool_calls": [
+                            {
+                                "id": "call_abc123",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_current_temperature",
+                                    "arguments": json.dumps(
+                                        {
+                                            "location": "San Francisco, CA",
+                                            "unit": "Farenheit",
+                                        }
+                                    ),
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        )
+        state_store.beta.threads.runs.put(run)
+        return Response(200, request=request, json=run.model_dump())
+
+
+@openai_responses.mock()
+def test_external_api_mock(openai_mock: OpenAIMock):
+    client = openai.Client(api_key="sk-fake123")
+
+    assistant = client.beta.assistants.create(
+        instructions="You are a weather bot. Use the provided functions to answer questions.",
+        model="gpt-4o",
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_temperature",
+                    "description": "Get the current temperature for a specific location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The city and state, e.g., San Francisco, CA",
+                            },
+                            "unit": {
+                                "type": "string",
+                                "enum": ["Celsius", "Fahrenheit"],
+                                "description": "The temperature unit to use. Infer this from the user's location.",
+                            },
+                        },
+                        "required": ["location", "unit"],
+                    },
+                },
+            },
+        ],
+    )
+
+    thread = client.beta.threads.create()
+    client.beta.threads.messages.create(
+        thread_id=thread.id,
+        role="user",
+        content="What's the weather in San Francisco today?",
+    )
+
+    run = client.beta.threads.runs.create(
+        thread_id=thread.id,
+        assistant_id=assistant.id,
+    )
+
+    # add response with side effects
+    openai_mock.beta.threads.runs.retrieve.response = polled_get_run_responses
+
+    # add new mock for non-OpenAI API
+    openai_mock.router.post(url="https://api.myweatherapi.com").mock(
+        Response(200, json={"value": "57"})
+    )
+
+    while True:
+        run = client.beta.threads.runs.retrieve(run.id, thread_id=thread.id)
+        if run.status == "requires_action":
+            assert run.required_action
+            tool_outputs: list[ToolOutput] = []
+            for tool in run.required_action.submit_tool_outputs.tool_calls:
+                if tool.function.name == "get_current_temperature":
+                    res = httpx.post(
+                        url="https://api.myweatherapi.com",
+                        json=json.loads(tool.function.arguments),
+                    )
+                    data: dict[str, str] = res.json()
+                    tool_outputs.append(
+                        {
+                            "tool_call_id": tool.id,
+                            "output": data["value"],
+                        }
+                    )
+                else:
+                    raise ValueError
+
+            assert len(tool_outputs) > 0
+            client.beta.threads.runs.submit_tool_outputs(
+                run.id,
+                thread_id=thread.id,
+                tool_outputs=tool_outputs,
+            )
+            break
+        else:
+            continue
+
+    assert openai_mock.beta.assistants.create.calls.call_count == 1
+    assert openai_mock.beta.threads.create.calls.call_count == 1
+    assert openai_mock.beta.threads.messages.create.calls.call_count == 1
+    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
+    assert openai_mock.beta.threads.runs.retrieve.calls.call_count == 5
+    assert openai_mock.beta.threads.runs.submit_tool_outputs.calls.call_count == 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - user_guide/responses.md
       - user_guide/async.md
       - user_guide/helpers.md
+      - user_guide/external.md
   - Routes:
     - routes/index.md
   

--- a/src/openai_responses/helpers/mergers/_base.py
+++ b/src/openai_responses/helpers/mergers/_base.py
@@ -1,0 +1,10 @@
+from typing import Any, Mapping, Type
+from ..._types.generics import M
+from ..._utils.serde import model_dict, model_parse
+
+__all__ = ["_generic_merge_with_partial"]
+
+
+def _generic_merge_with_partial(t: Type[M], m: M, p: Mapping[str, Any]) -> M:
+    merged = model_dict(m) | dict(p)
+    return model_parse(t, merged)

--- a/src/openai_responses/helpers/mergers/runs.py
+++ b/src/openai_responses/helpers/mergers/runs.py
@@ -1,0 +1,11 @@
+from openai.types.beta.threads.run import Run
+
+from ._base import _generic_merge_with_partial
+
+from ..._types.partials.runs import PartialRun
+
+__all__ = ["merge_run_with_partial"]
+
+
+def merge_run_with_partial(r: Run, p: PartialRun) -> Run:
+    return _generic_merge_with_partial(Run, r, p)


### PR DESCRIPTION
Exposes instance of [respx.MockRouter](https://github.com/lundberg/respx/blob/366dd0bea824464e6ec9242a88f9b390a9dd74cb/respx/router.py#L323) that contains the patched OpenAI routes.

This allows the user to access that router to define their own mocks for non-OpenAI routes or allow API calls to actually be passed through to external services.
