### PR TITLE
chore(routers): always use verbose match names

### DIFF
--- a/examples/test_router_usage.py
+++ b/examples/test_router_usage.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 import httpx
 import openai
@@ -14,10 +13,9 @@ def polled_get_run_responses(
     request: Request,
     route: Route,
     state_store: StateStore,
-    **kwargs: Any,
+    thread_id: str,
+    run_id: str,
 ) -> Response:
-    # RESPX will inject `id` (for run ID) and `thread_id` into the kwargs
-    run_id = kwargs["id"]
     run = state_store.beta.threads.runs.get(run_id)
     assert run
     if route.call_count < 4:
@@ -29,6 +27,7 @@ def polled_get_run_responses(
         run = merge_run_with_partial(
             run,
             {
+                "thread_id": thread_id,
                 "status": "requires_action",
                 "required_action": {
                     "type": "submit_tool_outputs",

--- a/src/openai_responses/_routes/assistants.py
+++ b/src/openai_responses/_routes/assistants.py
@@ -105,7 +105,9 @@ class AssistantListRoute(
 class AssistantRetrieveRoute(StatefulRoute[Assistant, PartialAssistant]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.get(url__regex=r"/assistants/(?P<id>[a-zA-Z0-9\_]+)"),
+            route=router.get(
+                url__regex=r"/assistants/(?P<assistant_id>[a-zA-Z0-9\_]+)"
+            ),
             status_code=200,
             state=state,
         )
@@ -118,8 +120,8 @@ class AssistantRetrieveRoute(StatefulRoute[Assistant, PartialAssistant]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        found = self._state.beta.assistants.get(id)
+        assistant_id = kwargs["assistant_id"]
+        found = self._state.beta.assistants.get(assistant_id)
         if not found:
             return httpx.Response(404)
 
@@ -133,7 +135,9 @@ class AssistantRetrieveRoute(StatefulRoute[Assistant, PartialAssistant]):
 class AssistantUpdateRoute(StatefulRoute[Assistant, PartialAssistant]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.post(url__regex=r"/assistants/(?P<id>[a-zA-Z0-9\_]+)"),
+            route=router.post(
+                url__regex=r"/assistants/(?P<assistant_id>[a-zA-Z0-9\_]+)"
+            ),
             status_code=200,
             state=state,
         )
@@ -146,8 +150,8 @@ class AssistantUpdateRoute(StatefulRoute[Assistant, PartialAssistant]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        found = self._state.beta.assistants.get(id)
+        assistant_id = kwargs["assistant_id"]
+        found = self._state.beta.assistants.get(assistant_id)
         if not found:
             return httpx.Response(404)
 
@@ -166,7 +170,9 @@ class AssistantUpdateRoute(StatefulRoute[Assistant, PartialAssistant]):
 class AssistantDeleteRoute(StatefulRoute[AssistantDeleted, PartialAssistantDeleted]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.delete(url__regex=r"/assistants/(?P<id>[a-zA-Z0-9\_]+)"),
+            route=router.delete(
+                url__regex=r"/assistants/(?P<assistant_id>[a-zA-Z0-9\_]+)"
+            ),
             status_code=200,
             state=state,
         )
@@ -179,12 +185,14 @@ class AssistantDeleteRoute(StatefulRoute[AssistantDeleted, PartialAssistantDelet
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        deleted = self._state.beta.assistants.delete(id)
+        assistant_id = kwargs["assistant_id"]
+        deleted = self._state.beta.assistants.delete(assistant_id)
         return httpx.Response(
             status_code=200,
             json=model_dict(
-                AssistantDeleted(id=id, deleted=deleted, object="assistant.deleted")
+                AssistantDeleted(
+                    id=assistant_id, deleted=deleted, object="assistant.deleted"
+                )
             ),
         )
 

--- a/src/openai_responses/_routes/files.py
+++ b/src/openai_responses/_routes/files.py
@@ -102,7 +102,7 @@ class FileListRoute(StatefulRoute[SyncPage[FileObject], PartialFileList]):
 class FileRetrieveRoute(StatefulRoute[FileObject, PartialFileObject]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.get(url__regex=r"/files/(?P<id>[a-zA-Z0-9\-]+)"),
+            route=router.get(url__regex=r"/files/(?P<file_id>[a-zA-Z0-9\-]+)"),
             status_code=200,
             state=state,
         )
@@ -115,8 +115,8 @@ class FileRetrieveRoute(StatefulRoute[FileObject, PartialFileObject]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        found = self._state.files.get(id)
+        fil_id = kwargs["file_id"]
+        found = self._state.files.get(fil_id)
         if not found:
             return httpx.Response(404)
 
@@ -133,7 +133,7 @@ class FileRetrieveRoute(StatefulRoute[FileObject, PartialFileObject]):
 class FileDeleteRoute(StatefulRoute[FileObject, PartialFileDeleted]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.delete(url__regex=r"/files/(?P<id>[a-zA-Z0-9\-]+)"),
+            route=router.delete(url__regex=r"/files/(?P<file_id>[a-zA-Z0-9\-]+)"),
             status_code=200,
             state=state,
         )
@@ -146,11 +146,11 @@ class FileDeleteRoute(StatefulRoute[FileObject, PartialFileDeleted]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        deleted = self._state.files.delete(id)
+        file_id = kwargs["file_id"]
+        deleted = self._state.files.delete(file_id)
         return httpx.Response(
             status_code=200,
-            json=model_dict(FileDeleted(id=id, deleted=deleted, object="file")),
+            json=model_dict(FileDeleted(id=file_id, deleted=deleted, object="file")),
         )
 
     @staticmethod

--- a/src/openai_responses/_routes/messages.py
+++ b/src/openai_responses/_routes/messages.py
@@ -147,7 +147,7 @@ class MessageRetrieveRoute(StatefulRoute[Message, PartialMessage]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.get(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/messages/(?P<id>[a-zA-Z0-9\_]+)"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/messages/(?P<message_id>[a-zA-Z0-9\_]+)"
             ),
             status_code=200,
             state=state,
@@ -167,8 +167,8 @@ class MessageRetrieveRoute(StatefulRoute[Message, PartialMessage]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_message = self._state.beta.threads.messages.get(id)
+        message_id = kwargs["message_id"]
+        found_message = self._state.beta.threads.messages.get(message_id)
         if not found_message:
             return httpx.Response(404)
 
@@ -183,7 +183,7 @@ class MessageUpdateRoute(StatefulRoute[Message, PartialMessage]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.post(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/messages/(?P<id>[a-zA-Z0-9\_]+)"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/messages/(?P<message_id>[a-zA-Z0-9\_]+)"
             ),
             status_code=200,
             state=state,
@@ -203,8 +203,8 @@ class MessageUpdateRoute(StatefulRoute[Message, PartialMessage]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_message = self._state.beta.threads.messages.get(id)
+        message_id = kwargs["message_id"]
+        found_message = self._state.beta.threads.messages.get(message_id)
         if not found_message:
             return httpx.Response(404)
 
@@ -224,7 +224,7 @@ class MessageDeleteRoute(StatefulRoute[MessageDeleted, PartialMessageDeleted]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.delete(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/messages/(?P<id>[a-zA-Z0-9\_]+)"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/messages/(?P<message_id>[a-zA-Z0-9\_]+)"
             ),
             status_code=200,
             state=state,
@@ -244,12 +244,14 @@ class MessageDeleteRoute(StatefulRoute[MessageDeleted, PartialMessageDeleted]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        deleted = self._state.beta.threads.messages.delete(id)
+        message_id = kwargs["message_id"]
+        deleted = self._state.beta.threads.messages.delete(message_id)
         return httpx.Response(
             status_code=200,
             json=model_dict(
-                MessageDeleted(id=id, deleted=deleted, object="thread.message.deleted")
+                MessageDeleted(
+                    id=message_id, deleted=deleted, object="thread.message.deleted"
+                )
             ),
         )
 

--- a/src/openai_responses/_routes/run_steps.py
+++ b/src/openai_responses/_routes/run_steps.py
@@ -85,7 +85,7 @@ class RunStepRetrieveRoute(StatefulRoute[RunStep, PartialRunStep]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.get(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<run_id>[a-zA-Z0-9\_]+)/steps/(?P<id>[a-zA-Z0-9\_]+)"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<run_id>[a-zA-Z0-9\_]+)/steps/(?P<step_id>[a-zA-Z0-9\_]+)"
             ),
             status_code=200,
             state=state,
@@ -110,8 +110,8 @@ class RunStepRetrieveRoute(StatefulRoute[RunStep, PartialRunStep]):
         if not found_run:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_run_step = self._state.beta.threads.runs.steps.get(id)
+        step_id = kwargs["step_id"]
+        found_run_step = self._state.beta.threads.runs.steps.get(step_id)
         if not found_run_step:
             return httpx.Response(404)
 

--- a/src/openai_responses/_routes/runs.py
+++ b/src/openai_responses/_routes/runs.py
@@ -204,7 +204,7 @@ class RunRetrieveRoute(StatefulRoute[Run, PartialRun]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.get(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<id>[a-zA-Z0-9\_]+)"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<run_id>[a-zA-Z0-9\_]+)"
             ),
             status_code=200,
             state=state,
@@ -224,8 +224,8 @@ class RunRetrieveRoute(StatefulRoute[Run, PartialRun]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_run = self._state.beta.threads.runs.get(id)
+        run_id = kwargs["run_id"]
+        found_run = self._state.beta.threads.runs.get(run_id)
         if not found_run:
             return httpx.Response(404)
 
@@ -240,7 +240,7 @@ class RunUpdateRoute(StatefulRoute[Run, PartialRun]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.post(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<id>[a-zA-Z0-9\_]+)"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<run_id>[a-zA-Z0-9\_]+)"
             ),
             status_code=200,
             state=state,
@@ -260,8 +260,8 @@ class RunUpdateRoute(StatefulRoute[Run, PartialRun]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_run = self._state.beta.threads.runs.get(id)
+        run_id = kwargs["run_id"]
+        found_run = self._state.beta.threads.runs.get(run_id)
         if not found_run:
             return httpx.Response(404)
 
@@ -281,7 +281,7 @@ class RunSubmitToolOutputsRoute(StatefulRoute[Run, PartialRun]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.post(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<id>[a-zA-Z0-9\_]+)/submit_tool_outputs"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<run_id>[a-zA-Z0-9\_]+)/submit_tool_outputs"
             ),
             status_code=200,
             state=state,
@@ -302,8 +302,8 @@ class RunSubmitToolOutputsRoute(StatefulRoute[Run, PartialRun]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_run = self._state.beta.threads.runs.get(id)
+        run_id = kwargs["run_id"]
+        found_run = self._state.beta.threads.runs.get(run_id)
         if not found_run:
             return httpx.Response(404)
 
@@ -318,7 +318,7 @@ class RunCancelRoute(StatefulRoute[Run, PartialRun]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.post(
-                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<id>[a-zA-Z0-9\_]+)/cancel"
+                url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)/runs/(?P<run_id>[a-zA-Z0-9\_]+)/cancel"
             ),
             status_code=200,
             state=state,
@@ -339,8 +339,8 @@ class RunCancelRoute(StatefulRoute[Run, PartialRun]):
         if not found_thread:
             return httpx.Response(404)
 
-        id = kwargs["id"]
-        found_run = self._state.beta.threads.runs.get(id)
+        run_id = kwargs["run_id"]
+        found_run = self._state.beta.threads.runs.get(run_id)
         if not found_run:
             return httpx.Response(404)
 

--- a/src/openai_responses/_routes/threads.py
+++ b/src/openai_responses/_routes/threads.py
@@ -75,7 +75,7 @@ class ThreadCreateRoute(StatefulRoute[Thread, PartialThread]):
 class ThreadRetrieveRoute(StatefulRoute[Thread, PartialThread]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.get(url__regex=r"/threads/(?P<id>[a-zA-Z0-9\_]+)"),
+            route=router.get(url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)"),
             status_code=200,
             state=state,
         )
@@ -88,8 +88,8 @@ class ThreadRetrieveRoute(StatefulRoute[Thread, PartialThread]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        found = self._state.beta.threads.get(id)
+        thread_id = kwargs["thread_id"]
+        found = self._state.beta.threads.get(thread_id)
         if not found:
             return httpx.Response(404)
 
@@ -104,7 +104,7 @@ class ThreadUpdateRoute(StatefulRoute[Thread, PartialThread]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
             route=router.post(
-                url__regex=r"/threads/(?P<id>(?!.*runs)[a-zA-Z0-9_]+)"  # NOTE: avoids match on /threads/runs
+                url__regex=r"/threads/(?P<thread_id>(?!.*runs)[a-zA-Z0-9_]+)"  # NOTE: avoids match on /threads/runs
             ),
             status_code=200,
             state=state,
@@ -118,8 +118,8 @@ class ThreadUpdateRoute(StatefulRoute[Thread, PartialThread]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        found = self._state.beta.threads.get(id)
+        thread_id = kwargs["thread_id"]
+        found = self._state.beta.threads.get(thread_id)
         if not found:
             return httpx.Response(404)
 
@@ -138,7 +138,7 @@ class ThreadUpdateRoute(StatefulRoute[Thread, PartialThread]):
 class ThreadDeleteRoute(StatefulRoute[ThreadDeleted, PartialThreadDeleted]):
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         super().__init__(
-            route=router.delete(url__regex=r"/threads/(?P<id>[a-zA-Z0-9\_]+)"),
+            route=router.delete(url__regex=r"/threads/(?P<thread_id>[a-zA-Z0-9\_]+)"),
             status_code=200,
             state=state,
         )
@@ -151,12 +151,12 @@ class ThreadDeleteRoute(StatefulRoute[ThreadDeleted, PartialThreadDeleted]):
         **kwargs: Any,
     ) -> httpx.Response:
         self._route = route
-        id = kwargs["id"]
-        deleted = self._state.beta.threads.delete(id)
+        thread_id = kwargs["thread_id"]
+        deleted = self._state.beta.threads.delete(thread_id)
         return httpx.Response(
             status_code=200,
             json=model_dict(
-                ThreadDeleted(id=id, deleted=deleted, object="thread.deleted")
+                ThreadDeleted(id=thread_id, deleted=deleted, object="thread.deleted")
             ),
         )
 


### PR DESCRIPTION
In the URL regex matches, we should always prefer verbose names like `run_id` to just `id`.
