### PR TITLE
feat(routes): expose respx route as prop

### DIFF
--- a/examples/test_assistants.py
+++ b/examples/test_assistants.py
@@ -16,7 +16,7 @@ def test_create_assistant(openai_mock: OpenAIMock):
     )
 
     assert assistant.name == "Math Tutor"
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -34,8 +34,8 @@ def test_list_assistants(openai_mock: OpenAIMock):
     assistants = client.beta.assistants.list()
 
     assert len(assistants.data) == 10
-    assert openai_mock.beta.assistants.create.calls.call_count == 10
-    assert openai_mock.beta.assistants.list.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 10
+    assert openai_mock.beta.assistants.list.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -53,8 +53,8 @@ def test_retrieve_assistant(openai_mock: OpenAIMock):
 
     assert assistant.name == "Math Tutor"
     assert found.name == assistant.name
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.assistants.retrieve.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.assistants.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -79,8 +79,8 @@ def test_update_assistant(openai_mock: OpenAIMock):
     assert assistant.model == "gpt-4-turbo"
     assert updated.name == "Math Tutor (Slim)"
     assert updated.model == "gpt-3.5-turbo"
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.assistants.update.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.assistants.update.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -95,5 +95,5 @@ def test_delete_assistant(openai_mock: OpenAIMock):
     )
 
     assert client.beta.assistants.delete(assistant.id).deleted
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.assistants.delete.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.assistants.delete.route.call_count == 1

--- a/examples/test_async_client.py
+++ b/examples/test_async_client.py
@@ -30,4 +30,4 @@ async def test_async_create_chat_completion(openai_mock: OpenAIMock):
 
     assert len(completion.choices) == 1
     assert completion.choices[0].message.content == "Hello! How can I help?"
-    assert openai_mock.chat.completions.create.calls.call_count == 1
+    assert openai_mock.chat.completions.create.route.call_count == 1

--- a/examples/test_azure_client.py
+++ b/examples/test_azure_client.py
@@ -34,4 +34,4 @@ def test_create_chat_completion(openai_mock: OpenAIMock):
 
     assert len(completion.choices) == 1
     assert completion.choices[0].message.content == "Hello! How can I help?"
-    assert openai_mock.chat.completions.create.calls.call_count == 1
+    assert openai_mock.chat.completions.create.route.call_count == 1

--- a/examples/test_chat_completion.py
+++ b/examples/test_chat_completion.py
@@ -27,4 +27,4 @@ def test_create_chat_completion(openai_mock: OpenAIMock):
 
     assert len(completion.choices) == 1
     assert completion.choices[0].message.content == "Hello! How can I help?"
-    assert openai_mock.chat.completions.create.calls.call_count == 1
+    assert openai_mock.chat.completions.create.route.call_count == 1

--- a/examples/test_context_manager.py
+++ b/examples/test_context_manager.py
@@ -31,4 +31,4 @@ def test_create_chat_completion():
 
         assert len(completion.choices) == 1
         assert completion.choices[0].message.content == "Hello! How can I help?"
-        assert openai_mock.chat.completions.create.calls.call_count == 1
+        assert openai_mock.chat.completions.create.route.call_count == 1

--- a/examples/test_custom_response_handler.py
+++ b/examples/test_custom_response_handler.py
@@ -30,4 +30,4 @@ def test_create_chat_completion(openai_mock: OpenAIMock):
         ],
     )
 
-    assert openai_mock.chat.completions.create.calls.call_count == 3
+    assert openai_mock.chat.completions.create.route.call_count == 3

--- a/examples/test_embeddings.py
+++ b/examples/test_embeddings.py
@@ -30,3 +30,4 @@ def test_create_embedding(openai_mock: OpenAIMock):
     assert len(embeddings.data) == 1
     assert embeddings.data[0].embedding == EMBEDDING
     assert embeddings.data[0]
+    assert openai_mock.embeddings.create.route.call_count == 1

--- a/examples/test_explicit_model.py
+++ b/examples/test_explicit_model.py
@@ -43,4 +43,4 @@ def test_create_chat_completion(openai_mock: OpenAIMock):
         completion.choices[0].message.content
         == "Hello there, how may I assist you today?"
     )
-    assert openai_mock.chat.completions.create.calls.call_count == 1
+    assert openai_mock.chat.completions.create.route.call_count == 1

--- a/examples/test_files.py
+++ b/examples/test_files.py
@@ -14,7 +14,7 @@ def test_create_file(openai_mock: OpenAIMock):
     )
 
     assert file.filename == "example.json"
-    assert openai_mock.files.create.calls.call_count == 1
+    assert openai_mock.files.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -30,8 +30,8 @@ def test_list_files(openai_mock: OpenAIMock):
     files = client.files.list()
 
     assert len(files.data) == 10
-    assert openai_mock.files.create.calls.call_count == 10
-    assert openai_mock.files.list.calls.call_count == 1
+    assert openai_mock.files.create.route.call_count == 10
+    assert openai_mock.files.list.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -48,8 +48,8 @@ def test_retrieve_file(openai_mock: OpenAIMock):
     assert found.id == file.id
     assert file.filename == "example.json"
     assert found.filename == file.filename
-    assert openai_mock.files.create.calls.call_count == 1
-    assert openai_mock.files.retrieve.calls.call_count == 1
+    assert openai_mock.files.create.route.call_count == 1
+    assert openai_mock.files.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -61,6 +61,6 @@ def test_delete_file(openai_mock: OpenAIMock):
         purpose="fine-tune",
     )
 
-    assert client.files.delete(file.id).deleted == True
-    assert openai_mock.files.create.calls.call_count == 1
-    assert openai_mock.files.delete.calls.call_count == 1
+    assert client.files.delete(file.id).deleted
+    assert openai_mock.files.create.route.call_count == 1
+    assert openai_mock.files.delete.route.call_count == 1

--- a/examples/test_messages.py
+++ b/examples/test_messages.py
@@ -16,8 +16,8 @@ def test_create_message(openai_mock: OpenAIMock):
 
     assert message.id
     assert message.thread_id == thread.id
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.create.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -35,13 +35,13 @@ def test_list_messages(openai_mock: OpenAIMock):
     messages = client.beta.threads.messages.list(thread.id)
 
     assert len(messages.data) == 10
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.create.calls.call_count == 10
-    assert openai_mock.beta.threads.messages.list.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.create.route.call_count == 10
+    assert openai_mock.beta.threads.messages.list.route.call_count == 1
 
     messages = client.beta.threads.messages.list(thread.id, limit=4, order="desc")
     assert len(messages.data) == 4
-    assert openai_mock.beta.threads.messages.list.calls.call_count == 2
+    assert openai_mock.beta.threads.messages.list.route.call_count == 2
 
 
 @openai_responses.mock()
@@ -57,9 +57,9 @@ def test_retrieve_message(openai_mock: OpenAIMock):
     found = client.beta.threads.messages.retrieve(message.id, thread_id=thread.id)
 
     assert found.id == message.id
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.retrieve.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -82,9 +82,9 @@ def test_update_message(openai_mock: OpenAIMock):
     assert updated.id == message.id
     assert message.metadata == {"foo": "1"}
     assert updated.metadata == {"foo": "2"}
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.update.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.update.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -100,6 +100,6 @@ def test_delete_message(openai_mock: OpenAIMock):
     )
 
     assert client.beta.threads.messages.delete(message.id, thread_id=thread.id).deleted
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.delete.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.delete.route.call_count == 1

--- a/examples/test_router_usage.py
+++ b/examples/test_router_usage.py
@@ -141,9 +141,9 @@ def test_external_api_mock(openai_mock: OpenAIMock):
         else:
             continue
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.messages.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.retrieve.calls.call_count == 5
-    assert openai_mock.beta.threads.runs.submit_tool_outputs.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.messages.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.retrieve.route.call_count == 5
+    assert openai_mock.beta.threads.runs.submit_tool_outputs.route.call_count == 1

--- a/examples/test_runs.py
+++ b/examples/test_runs.py
@@ -28,9 +28,9 @@ def test_create_run(openai_mock: OpenAIMock):
     assert run.instructions == assistant.instructions
     assert run.tools == assistant.tools
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -60,8 +60,8 @@ def test_create_thread_run(openai_mock: OpenAIMock):
     assert run.tools == assistant.tools
     assert len(messages.data) == 1
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create_and_run.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create_and_run.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -87,10 +87,10 @@ def test_list_runs(openai_mock: OpenAIMock):
 
     assert len(runs.data) == 10
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 10
-    assert openai_mock.beta.threads.runs.list.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 10
+    assert openai_mock.beta.threads.runs.list.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -115,10 +115,10 @@ def test_retrieve_run(openai_mock: OpenAIMock):
 
     assert found.id == run.id
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.retrieve.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -150,10 +150,10 @@ def test_update_run(openai_mock: OpenAIMock):
     assert run.metadata == {"foo": "1"}
     assert updated.metadata == {"foo": "2"}
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.update.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.update.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -180,8 +180,8 @@ def test_cancel_run(openai_mock: OpenAIMock):
     assert cancelled.status == "cancelling"
     assert found.status == "cancelled"
 
-    assert openai_mock.beta.assistants.create.calls.call_count == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.cancel.calls.call_count == 1
-    assert openai_mock.beta.threads.runs.retrieve.calls.call_count == 1
+    assert openai_mock.beta.assistants.create.route.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1
+    assert openai_mock.beta.threads.runs.cancel.route.call_count == 1
+    assert openai_mock.beta.threads.runs.retrieve.route.call_count == 1

--- a/examples/test_streaming.py
+++ b/examples/test_streaming.py
@@ -119,4 +119,4 @@ def test_handle_stream(openai_mock: OpenAIMock):
     assert event_count == 4
     assert len(messages.data) == 2
 
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1

--- a/examples/test_streaming_async.py
+++ b/examples/test_streaming_async.py
@@ -122,4 +122,4 @@ async def test_handle_stream(openai_mock: OpenAIMock):
     assert event_count == 4
     assert len(messages.data) == 2
 
-    assert openai_mock.beta.threads.runs.create.calls.call_count == 1
+    assert openai_mock.beta.threads.runs.create.route.call_count == 1

--- a/examples/test_threads.py
+++ b/examples/test_threads.py
@@ -11,7 +11,7 @@ def test_create_thread(openai_mock: OpenAIMock):
     thread = client.beta.threads.create()
 
     assert thread.id
-    assert openai_mock.beta.threads.create.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -26,7 +26,7 @@ def test_create_thread_with_additional_messages(openai_mock: OpenAIMock):
 
     assert thread.id
     assert len(messages.data) == 1
-    assert openai_mock.beta.threads.create.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -37,8 +37,8 @@ def test_retrieve_thread(openai_mock: OpenAIMock):
     found = client.beta.threads.retrieve(thread.id)
 
     assert found.id == thread.id
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.retrieve.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -51,8 +51,8 @@ def test_update_thread(openai_mock: OpenAIMock):
     assert updated.id == thread.id
     assert thread.metadata == {"foo": "bar"}
     assert updated.metadata == {"foo": "baz"}
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.update.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.update.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -62,5 +62,5 @@ def test_delete_thread(openai_mock: OpenAIMock):
     thread = client.beta.threads.create()
 
     assert client.beta.threads.delete(thread.id).deleted
-    assert openai_mock.beta.threads.create.calls.call_count == 1
-    assert openai_mock.beta.threads.delete.calls.call_count == 1
+    assert openai_mock.beta.threads.create.route.call_count == 1
+    assert openai_mock.beta.threads.delete.route.call_count == 1

--- a/examples/test_transport.py
+++ b/examples/test_transport.py
@@ -36,4 +36,4 @@ def test_create_chat_completion():
 
     assert len(completion.choices) == 1
     assert completion.choices[0].message.content == "Hello! How can I help?"
-    assert openai_mock.chat.completions.create.calls.call_count == 1
+    assert openai_mock.chat.completions.create.route.call_count == 1

--- a/src/openai_responses/_routes/_base.py
+++ b/src/openai_responses/_routes/_base.py
@@ -30,8 +30,8 @@ class Route(ABC, Generic[M, P]):
         self._route.side_effect = self._response
 
     @property
-    def calls(self):
-        return self._route.calls
+    def route(self) -> respx.Route:
+        return self._route
 
     @property
     def response(self) -> Union[httpx.Response, M, P, Callable[..., httpx.Response]]:


### PR DESCRIPTION
This replaces the `calls` property since that is available under `route`
