### PR TITLE
fix(streaming): force use of explicit event types

### DIFF
--- a/examples/test_streaming_async.py
+++ b/examples/test_streaming_async.py
@@ -5,13 +5,19 @@ import pytest
 
 import openai
 from openai import AsyncAssistantEventHandler
-from openai.types.beta import AssistantStreamEvent
 from openai.types.beta.threads import Run
+from openai.types.beta.assistant_stream_event import (
+    AssistantStreamEvent,
+    ThreadMessageCreated,
+    ThreadRunCompleted,
+    ThreadRunCreated,
+    ThreadRunInProgress,
+)
 
 import openai_responses
 from openai_responses import OpenAIMock
 from openai_responses.stores import StateStore
-from openai_responses.streaming import AsyncEventStream, Event
+from openai_responses.streaming import AsyncEventStream
 from openai_responses.helpers.builders.runs import run_from_create_request
 from openai_responses.helpers.builders.messages import build_message
 from openai_responses.ext.httpx import Request, Response
@@ -32,19 +38,19 @@ class EventHandler(AsyncAssistantEventHandler):
             event_count += 1
 
 
-class CreateRunEventStream(AsyncEventStream):
+class CreateRunEventStream(AsyncEventStream[AssistantStreamEvent]):
     def __init__(self, created_run: Run, state_store: StateStore) -> None:
         self.created_run = created_run
         self.state_store = state_store
 
     @override
-    def generate(self) -> Generator[Event, None, None]:
+    def generate(self) -> Generator[AssistantStreamEvent, None, None]:
         self.state_store.beta.threads.runs.put(self.created_run)
-        yield self.event("thread.run.created", self.created_run)
+        yield ThreadRunCreated(event="thread.run.created", data=self.created_run)
 
         self.created_run.status = "in_progress"
         self.state_store.beta.threads.runs.put(self.created_run)
-        yield self.event("thread.run.in_progress", self.created_run)
+        yield ThreadRunInProgress(event="thread.run.in_progress", data=self.created_run)
 
         assistant_message = build_message(
             {
@@ -62,11 +68,13 @@ class CreateRunEventStream(AsyncEventStream):
             }
         )
         self.state_store.beta.threads.messages.put(assistant_message)
-        yield self.event("thread.message.created", assistant_message)
+        yield ThreadMessageCreated(
+            event="thread.message.created", data=assistant_message
+        )
 
         self.created_run.status = "completed"
         self.state_store.beta.threads.runs.put(self.created_run)
-        yield self.event("thread.run.completed", self.created_run)
+        yield ThreadRunCompleted(event="thread.run.completed", data=self.created_run)
 
 
 def create_run_stream_response(

--- a/examples/test_streaming_simple.py
+++ b/examples/test_streaming_simple.py
@@ -6,74 +6,65 @@ from openai.types.chat import ChatCompletionChunk
 
 import openai_responses
 from openai_responses import OpenAIMock
-from openai_responses.streaming import Event, EventStream
+from openai_responses.streaming import EventStream
 from openai_responses.ext.httpx import Request, Response
 
 
-class CreateChatCompletionEventStream(EventStream):
+class CreateChatCompletionEventStream(EventStream[ChatCompletionChunk]):
     @override
-    def generate(self) -> Generator[Event, None, None]:
-        yield self.event(
-            None,
-            ChatCompletionChunk.model_validate(
-                {
-                    "id": "chatcmpl-123",
-                    "object": "chat.completion.chunk",
-                    "created": 1694268190,
-                    "model": "gpt-4o",
-                    "system_fingerprint": "fp_44709d6fcb",
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"role": "assistant", "content": ""},
-                            "logprobs": None,
-                            "finish_reason": None,
-                        }
-                    ],
-                }
-            ),
+    def generate(self) -> Generator[ChatCompletionChunk, None, None]:
+        yield ChatCompletionChunk.model_validate(
+            {
+                "id": "chatcmpl-123",
+                "object": "chat.completion.chunk",
+                "created": 1694268190,
+                "model": "gpt-4o",
+                "system_fingerprint": "fp_44709d6fcb",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "logprobs": None,
+                        "finish_reason": None,
+                    }
+                ],
+            }
         )
 
-        yield self.event(
-            None,
-            ChatCompletionChunk.model_validate(
-                {
-                    "id": "chatcmpl-123",
-                    "object": "chat.completion.chunk",
-                    "created": 1694268190,
-                    "model": "gpt-4o",
-                    "system_fingerprint": "fp_44709d6fcb",
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"content": "Hello"},
-                            "logprobs": None,
-                            "finish_reason": None,
-                        }
-                    ],
-                }
-            ),
+        yield ChatCompletionChunk.model_validate(
+            {
+                "id": "chatcmpl-123",
+                "object": "chat.completion.chunk",
+                "created": 1694268190,
+                "model": "gpt-4o",
+                "system_fingerprint": "fp_44709d6fcb",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "Hello"},
+                        "logprobs": None,
+                        "finish_reason": None,
+                    }
+                ],
+            }
         )
 
-        yield self.event(
-            None,
-            ChatCompletionChunk.model_validate(
-                {
-                    "id": "chatcmpl-123",
-                    "object": "chat.completion.chunk",
-                    "created": 1694268190,
-                    "model": "gpt-4o",
-                    "system_fingerprint": "fp_44709d6fcb",
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {},
-                            "logprobs": None,
-                            "finish_reason": "stop",
-                        }
-                    ],
-                }
-            ),
+        yield ChatCompletionChunk.model_validate(
+            {
+                "id": "chatcmpl-123",
+                "object": "chat.completion.chunk",
+                "created": 1694268190,
+                "model": "gpt-4o",
+                "system_fingerprint": "fp_44709d6fcb",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "logprobs": None,
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
         )
 
 


### PR DESCRIPTION
Breaking change that removes the `event` method on the event stream classes and forces the user to explicitly define and construct the generated events.

This will help cut down on feature drift overtime since this is relying on OpenAI's types instead of relying on custom code that tried to make this easier for the user.
