### PR TITLE
fix(routes): promote vector stores from beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pytest plugin for automatically mocking OpenAI requests. Powered by [RESPX](https://github.com/lundberg/respx).
 
-[![sdk support](https://img.shields.io/badge/SDK_Support-v1.50+-white?logo=openai&logoColor=black&labelColor=white)](https://github.com/openai/openai-python)
+[![sdk support](https://img.shields.io/badge/SDK_Support-v1.66+-white?logo=openai&logoColor=black&labelColor=white)](https://github.com/openai/openai-python)
 
 ## Supported Endpoints
 

--- a/examples/test_vector_store_file_batches.py
+++ b/examples/test_vector_store_file_batches.py
@@ -8,13 +8,13 @@ from openai_responses import OpenAIMock
 def test_create_vector_store_file_batch(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+    vector_store_file_batch = client.vector_stores.file_batches.create(
         vector_store_id=vector_store.id,
         file_ids=[file.id],
     )
@@ -23,53 +23,53 @@ def test_create_vector_store_file_batch(openai_mock: OpenAIMock):
     assert vector_store_file_batch.file_counts.completed == 1
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.create.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.create.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_retrieve_vector_store_file_batch(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+    vector_store_file_batch = client.vector_stores.file_batches.create(
         vector_store_id=vector_store.id,
         file_ids=[file.id],
     )
 
-    found = client.beta.vector_stores.file_batches.retrieve(
+    found = client.vector_stores.file_batches.retrieve(
         vector_store_file_batch.id, vector_store_id=vector_store.id
     )
 
     assert found.id == vector_store_file_batch.id
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.retrieve.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_cancel_vector_store_file_batch(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+    vector_store_file_batch = client.vector_stores.file_batches.create(
         vector_store_id=vector_store.id,
         file_ids=[file.id],
     )
 
-    cancelled = client.beta.vector_stores.file_batches.cancel(
+    cancelled = client.vector_stores.file_batches.cancel(
         vector_store_file_batch.id, vector_store_id=vector_store.id
     )
 
@@ -77,27 +77,27 @@ def test_cancel_vector_store_file_batch(openai_mock: OpenAIMock):
     assert cancelled.status == "cancelled"
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.cancel.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.cancel.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_list_files_for_vector_store_file_batch(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file_batch = client.beta.vector_stores.file_batches.create(
+    vector_store_file_batch = client.vector_stores.file_batches.create(
         vector_store_id=vector_store.id,
         file_ids=[file.id],
     )
 
-    files = client.beta.vector_stores.file_batches.list_files(
+    files = client.vector_stores.file_batches.list_files(
         vector_store_file_batch.id,
         vector_store_id=vector_store.id,
     )
@@ -105,6 +105,6 @@ def test_list_files_for_vector_store_file_batch(openai_mock: OpenAIMock):
     assert len(files.data) == 1
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.file_batches.list_files.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.create.route.call_count == 1
+    assert openai_mock.vector_stores.file_batches.list_files.route.call_count == 1

--- a/examples/test_vector_store_files.py
+++ b/examples/test_vector_store_files.py
@@ -8,13 +8,13 @@ from openai_responses import OpenAIMock
 def test_create_vector_store_file(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file = client.beta.vector_stores.files.create(
+    vector_store_file = client.vector_stores.files.create(
         vector_store_id=vector_store.id,
         file_id=file.id,
     )
@@ -23,15 +23,15 @@ def test_create_vector_store_file(openai_mock: OpenAIMock):
     assert vector_store_file.id == file.id
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.create.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.create.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_list_vector_store_files(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
 
     for _ in range(10):
         file = client.files.create(
@@ -39,37 +39,37 @@ def test_list_vector_store_files(openai_mock: OpenAIMock):
             purpose="assistants",
         )
 
-        client.beta.vector_stores.files.create(
+        client.vector_stores.files.create(
             vector_store_id=vector_store.id,
             file_id=file.id,
         )
 
-    vector_store_files = client.beta.vector_stores.files.list(vector_store.id)
+    vector_store_files = client.vector_stores.files.list(vector_store.id)
 
     assert len(vector_store_files.data) == 10
 
     assert openai_mock.files.create.route.call_count == 10
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.create.route.call_count == 10
-    assert openai_mock.beta.vector_stores.files.list.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.create.route.call_count == 10
+    assert openai_mock.vector_stores.files.list.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_retrieve_vector_store_file(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file = client.beta.vector_stores.files.create(
+    vector_store_file = client.vector_stores.files.create(
         vector_store_id=vector_store.id,
         file_id=file.id,
     )
 
-    found = client.beta.vector_stores.files.retrieve(
+    found = client.vector_stores.files.retrieve(
         vector_store_file.id,
         vector_store_id=vector_store.id,
     )
@@ -77,27 +77,27 @@ def test_retrieve_vector_store_file(openai_mock: OpenAIMock):
     assert found.id == vector_store_file.id
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.retrieve.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_delete_vector_store_file(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
     file = client.files.create(
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
 
-    vector_store_file = client.beta.vector_stores.files.create(
+    vector_store_file = client.vector_stores.files.create(
         vector_store_id=vector_store.id,
         file_id=file.id,
     )
 
-    deleted = client.beta.vector_stores.files.delete(
+    deleted = client.vector_stores.files.delete(
         vector_store_file.id,
         vector_store_id=vector_store.id,
     )
@@ -105,6 +105,6 @@ def test_delete_vector_store_file(openai_mock: OpenAIMock):
     assert deleted.deleted
 
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.delete.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.delete.route.call_count == 1

--- a/examples/test_vector_stores.py
+++ b/examples/test_vector_stores.py
@@ -8,10 +8,10 @@ from openai_responses import OpenAIMock
 def test_create_vector_store(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
 
     assert vector_store.name == "Support FAQ"
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -22,15 +22,13 @@ def test_create_vector_store_with_file_ids(openai_mock: OpenAIMock):
         file=open("examples/example.json", "rb"),
         purpose="assistants",
     )
-    vector_store = client.beta.vector_stores.create(
-        name="Support FAQ", file_ids=[file.id]
-    )
-    vector_store_files = client.beta.vector_stores.files.list(vector_store.id)
+    vector_store = client.vector_stores.create(name="Support FAQ", file_ids=[file.id])
+    vector_store_files = client.vector_stores.files.list(vector_store.id)
 
     assert len(vector_store_files.data) == 1
     assert openai_mock.files.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.list.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.files.list.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -57,16 +55,16 @@ def test_create_vector_store_from_assistant_create(openai_mock: OpenAIMock):
     assert assistant.tool_resources.file_search
     assert assistant.tool_resources.file_search.vector_store_ids
 
-    vector_store = client.beta.vector_stores.retrieve(
+    vector_store = client.vector_stores.retrieve(
         assistant.tool_resources.file_search.vector_store_ids[0]
     )
-    vector_store_files = client.beta.vector_stores.files.list(vector_store.id)
+    vector_store_files = client.vector_stores.files.list(vector_store.id)
 
     assert len(vector_store_files.data) == 1
     assert openai_mock.files.create.route.call_count == 1
     assert openai_mock.beta.assistants.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.retrieve.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.list.route.call_count == 1
+    assert openai_mock.vector_stores.retrieve.route.call_count == 1
+    assert openai_mock.vector_stores.files.list.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -92,16 +90,16 @@ def test_create_vector_store_from_thread_create(openai_mock: OpenAIMock):
     assert thread.tool_resources.file_search
     assert thread.tool_resources.file_search.vector_store_ids
 
-    vector_store = client.beta.vector_stores.retrieve(
+    vector_store = client.vector_stores.retrieve(
         thread.tool_resources.file_search.vector_store_ids[0]
     )
-    vector_store_files = client.beta.vector_stores.files.list(vector_store.id)
+    vector_store_files = client.vector_stores.files.list(vector_store.id)
 
     assert len(vector_store_files.data) == 1
     assert openai_mock.files.create.route.call_count == 1
     assert openai_mock.beta.threads.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.retrieve.route.call_count == 1
-    assert openai_mock.beta.vector_stores.files.list.route.call_count == 1
+    assert openai_mock.vector_stores.retrieve.route.call_count == 1
+    assert openai_mock.vector_stores.files.list.route.call_count == 1
 
 
 @openai_responses.mock()
@@ -109,52 +107,52 @@ def test_list_vector_stores(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
     for i in range(10):
-        client.beta.vector_stores.create(name=f"vector-store-{i}")
+        client.vector_stores.create(name=f"vector-store-{i}")
 
-    vector_stores = client.beta.vector_stores.list()
+    vector_stores = client.vector_stores.list()
 
     assert len(vector_stores.data) == 10
-    assert openai_mock.beta.vector_stores.create.route.call_count == 10
-    assert openai_mock.beta.vector_stores.list.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 10
+    assert openai_mock.vector_stores.list.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_retrieve_vector_store(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
 
-    found = client.beta.vector_stores.retrieve(vector_store.id)
+    found = client.vector_stores.retrieve(vector_store.id)
 
     assert vector_store.name == "Support FAQ"
     assert found.name == vector_store.name
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.retrieve.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.retrieve.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_update_vector_store(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
 
-    updated = client.beta.vector_stores.update(
+    updated = client.vector_stores.update(
         vector_store.id,
         name="Support FAQ Updated",
     )
 
     assert updated.id == vector_store.id
     assert updated.name == "Support FAQ Updated"
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.update.route.call_count == 1
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.update.route.call_count == 1
 
 
 @openai_responses.mock()
 def test_delete_vector_store(openai_mock: OpenAIMock):
     client = openai.Client(api_key="sk-fake123")
 
-    vector_store = client.beta.vector_stores.create(name="Support FAQ")
+    vector_store = client.vector_stores.create(name="Support FAQ")
 
-    assert client.beta.vector_stores.delete(vector_store.id).deleted
-    assert openai_mock.beta.vector_stores.create.route.call_count == 1
-    assert openai_mock.beta.vector_stores.delete.route.call_count == 1
+    assert client.vector_stores.delete(vector_store.id).deleted
+    assert openai_mock.vector_stores.create.route.call_count == 1
+    assert openai_mock.vector_stores.delete.route.call_count == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ openai_responses = "openai_responses.plugin"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-openai = ">=1.50,<2.0"
+openai = ">=1.66,<2.0"
 requests-toolbelt = "^1"
 respx = "^0.22.0"
 

--- a/src/openai_responses/_mock.py
+++ b/src/openai_responses/_mock.py
@@ -11,6 +11,7 @@ from ._routes import (
     FileRoutes,
     ModelRoutes,
     ModerationsRoutes,
+    VectorStoreRoutes,
 )
 from .stores import StateStore
 
@@ -59,9 +60,13 @@ class OpenAIMock:
         self.files = FileRoutes(self._router, self._state)
         self.models = ModelRoutes(self._router, self._state)
         self.moderations = ModerationsRoutes(self._router)
+        self.vector_stores = VectorStoreRoutes(self._router, self._state)
 
         # NOTE: need to sort routes to avoid match conflicts
-        self._router.routes._routes.sort(key=lambda r: len(repr(r._pattern)), reverse=True)  # type: ignore
+        self._router.routes._routes.sort(
+            key=lambda r: len(repr(r._pattern)),  # type: ignore
+            reverse=True,
+        )
 
     def _start_mock(self):
         def wrapper(fn: Callable[..., Any]):

--- a/src/openai_responses/_routes/__init__.py
+++ b/src/openai_responses/_routes/__init__.py
@@ -16,6 +16,27 @@ from .moderation import ModerationCreateRoute
 
 from .beta import BetaRoutes
 
+from .beta.vector_stores import (
+    VectorStoreCreateRoute,
+    VectorStoreListRoute,
+    VectorStoreRetrieveRoute,
+    VectorStoreUpdateRoute,
+    VectorStoreDeleteRoute,
+)
+from .beta.vector_store_files import (
+    VectorStoreFileCreateRoute,
+    VectorStoreFileListRoute,
+    VectorStoreFileRetrieveRoute,
+    VectorStoreFileDeleteRoute,
+)
+from .beta.vector_store_file_batches import (
+    VectorStoreFileBatchCreateRoute,
+    VectorStoreFileBatchRetrieveRoute,
+    VectorStoreFileBatchCancelRoute,
+    VectorStoreFileBatchListFilesRoute,
+)
+
+
 __all__ = [
     "BetaRoutes",
     "ChatRoutes",
@@ -23,6 +44,7 @@ __all__ = [
     "FileRoutes",
     "ModelRoutes",
     "ModerationsRoutes",
+    "VectorStoreRoutes",
 ]
 
 
@@ -59,3 +81,31 @@ class ModelRoutes:
 class ModerationsRoutes:
     def __init__(self, router: respx.MockRouter) -> None:
         self.create = ModerationCreateRoute(router)
+
+
+class VectorStoreRoutes:
+    def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
+        self.create = VectorStoreCreateRoute(router, state)
+        self.list = VectorStoreListRoute(router, state)
+        self.retrieve = VectorStoreRetrieveRoute(router, state)
+        self.update = VectorStoreUpdateRoute(router, state)
+        self.delete = VectorStoreDeleteRoute(router, state)
+
+        self.files = VectorStoreFileRoutes(router, state)
+        self.file_batches = VectorStoreFileBatchRoutes(router, state)
+
+
+class VectorStoreFileRoutes:
+    def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
+        self.create = VectorStoreFileCreateRoute(router, state)
+        self.list = VectorStoreFileListRoute(router, state)
+        self.retrieve = VectorStoreFileRetrieveRoute(router, state)
+        self.delete = VectorStoreFileDeleteRoute(router, state)
+
+
+class VectorStoreFileBatchRoutes:
+    def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
+        self.create = VectorStoreFileBatchCreateRoute(router, state)
+        self.retrieve = VectorStoreFileBatchRetrieveRoute(router, state)
+        self.cancel = VectorStoreFileBatchCancelRoute(router, state)
+        self.list_files = VectorStoreFileBatchListFilesRoute(router, state)

--- a/src/openai_responses/_routes/beta/__init__.py
+++ b/src/openai_responses/_routes/beta/__init__.py
@@ -33,25 +33,6 @@ from .runs import (
     RunCancelRoute,
 )
 from .run_steps import RunStepListRoute, RunStepRetrieveRoute
-from .vector_stores import (
-    VectorStoreCreateRoute,
-    VectorStoreListRoute,
-    VectorStoreRetrieveRoute,
-    VectorStoreUpdateRoute,
-    VectorStoreDeleteRoute,
-)
-from .vector_store_files import (
-    VectorStoreFileCreateRoute,
-    VectorStoreFileListRoute,
-    VectorStoreFileRetrieveRoute,
-    VectorStoreFileDeleteRoute,
-)
-from .vector_store_file_batches import (
-    VectorStoreFileBatchCreateRoute,
-    VectorStoreFileBatchRetrieveRoute,
-    VectorStoreFileBatchCancelRoute,
-    VectorStoreFileBatchListFilesRoute,
-)
 
 from .chat import ParsedChatCompletionsCreateRoute
 
@@ -63,8 +44,6 @@ class BetaRoutes:
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         self.assistants = AssistantsRoutes(router, state)
         self.threads = ThreadRoutes(router, state)
-        self.vector_stores = VectorStoreRoutes(router, state)
-
         self.chat = ChatRoutes(router)
 
 
@@ -114,34 +93,6 @@ class RunStepRoutes:
     def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
         self.list = RunStepListRoute(router, state)
         self.retrieve = RunStepRetrieveRoute(router, state)
-
-
-class VectorStoreRoutes:
-    def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
-        self.create = VectorStoreCreateRoute(router, state)
-        self.list = VectorStoreListRoute(router, state)
-        self.retrieve = VectorStoreRetrieveRoute(router, state)
-        self.update = VectorStoreUpdateRoute(router, state)
-        self.delete = VectorStoreDeleteRoute(router, state)
-
-        self.files = VectorStoreFileRoutes(router, state)
-        self.file_batches = VectorStoreFileBatchRoutes(router, state)
-
-
-class VectorStoreFileRoutes:
-    def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
-        self.create = VectorStoreFileCreateRoute(router, state)
-        self.list = VectorStoreFileListRoute(router, state)
-        self.retrieve = VectorStoreFileRetrieveRoute(router, state)
-        self.delete = VectorStoreFileDeleteRoute(router, state)
-
-
-class VectorStoreFileBatchRoutes:
-    def __init__(self, router: respx.MockRouter, state: StateStore) -> None:
-        self.create = VectorStoreFileBatchCreateRoute(router, state)
-        self.retrieve = VectorStoreFileBatchRetrieveRoute(router, state)
-        self.cancel = VectorStoreFileBatchCancelRoute(router, state)
-        self.list_files = VectorStoreFileBatchListFilesRoute(router, state)
 
 
 class ChatRoutes:

--- a/src/openai_responses/_routes/beta/assistants.py
+++ b/src/openai_responses/_routes/beta/assistants.py
@@ -62,7 +62,7 @@ class AssistantCreateRoute(StatefulRoute[Assistant, PartialAssistant]):
                         create_req = httpx.Request("", "", content=encoded)
                         vector_store = vector_store_from_create_request(create_req)
                         vector_store_ids.append(vector_store.id)
-                        self._state.beta.vector_stores.put(vector_store)
+                        self._state.vector_stores.put(vector_store)
                         for file_id in vector_store_create_params.get("file_ids", []):
                             found_file = self._state.files.get(file_id)
                             if not found_file:
@@ -73,7 +73,7 @@ class AssistantCreateRoute(StatefulRoute[Assistant, PartialAssistant]):
                                 create_file_req,
                                 extra={"vector_store_id": vector_store.id},
                             )
-                            self._state.beta.vector_stores.files.put(vector_store_file)
+                            self._state.vector_stores.files.put(vector_store_file)
 
                     model = merge_assistant_with_partial(
                         model,

--- a/src/openai_responses/_routes/beta/threads.py
+++ b/src/openai_responses/_routes/beta/threads.py
@@ -68,7 +68,7 @@ class ThreadCreateRoute(StatefulRoute[Thread, PartialThread]):
                         create_req = httpx.Request("", "", content=encoded)
                         vector_store = vector_store_from_create_request(create_req)
                         vector_store_ids.append(vector_store.id)
-                        self._state.beta.vector_stores.put(vector_store)
+                        self._state.vector_stores.put(vector_store)
                         for file_id in vector_store_create_params.get("file_ids", []):
                             found_file = self._state.files.get(file_id)
                             if not found_file:
@@ -79,7 +79,7 @@ class ThreadCreateRoute(StatefulRoute[Thread, PartialThread]):
                                 create_file_req,
                                 extra={"vector_store_id": vector_store.id},
                             )
-                            self._state.beta.vector_stores.files.put(vector_store_file)
+                            self._state.vector_stores.files.put(vector_store_file)
 
                     model = merge_thread_with_partial(
                         model,

--- a/src/openai_responses/_routes/beta/vector_store_file_batches.py
+++ b/src/openai_responses/_routes/beta/vector_store_file_batches.py
@@ -6,9 +6,9 @@ import httpx
 import respx
 
 from openai.pagination import SyncCursorPage
-from openai.types.beta.vector_stores.vector_store_file import VectorStoreFile
-from openai.types.beta.vector_stores.vector_store_file_batch import VectorStoreFileBatch
-from openai.types.beta.vector_stores.file_batch_create_params import (
+from openai.types.vector_stores.vector_store_file import VectorStoreFile
+from openai.types.vector_stores.vector_store_file_batch import VectorStoreFileBatch
+from openai.types.vector_stores.file_batch_create_params import (
     FileBatchCreateParams,
 )
 
@@ -56,7 +56,7 @@ class VectorStoreFileBatchCreateRoute(
         self._route = route
 
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
@@ -72,13 +72,13 @@ class VectorStoreFileBatchCreateRoute(
                 create_file_req,
                 extra={"vector_store_id": vector_store_id},
             )
-            self._state.beta.vector_stores.files.put(vector_store_file)
-            self._state.beta.vector_stores.file_batches.add_related_file(
+            self._state.vector_stores.files.put(vector_store_file)
+            self._state.vector_stores.file_batches.add_related_file(
                 model.id,
                 vector_store_file.id,
             )
 
-        self._state.beta.vector_stores.file_batches.put(model)
+        self._state.vector_stores.file_batches.put(model)
         return httpx.Response(status_code=self._status_code, json=model_dict(model))
 
     @staticmethod
@@ -125,12 +125,12 @@ class VectorStoreFileBatchRetrieveRoute(
         self._route = route
 
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
         batch_id = kwargs["batch_id"]
-        found = self._state.beta.vector_stores.file_batches.get(batch_id)
+        found = self._state.vector_stores.file_batches.get(batch_id)
         if not found:
             return httpx.Response(404)
 
@@ -166,17 +166,17 @@ class VectorStoreFileBatchCancelRoute(
         self._route = route
 
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
         batch_id = kwargs["batch_id"]
-        found = self._state.beta.vector_stores.file_batches.get(batch_id)
+        found = self._state.vector_stores.file_batches.get(batch_id)
         if not found:
             return httpx.Response(404)
 
         found.status = "cancelled"
-        self._state.beta.vector_stores.file_batches.put(found)
+        self._state.vector_stores.file_batches.put(found)
 
         return httpx.Response(status_code=self._status_code, json=model_dict(found))
 
@@ -212,12 +212,12 @@ class VectorStoreFileBatchListFilesRoute(
         self._route = route
 
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
         batch_id = kwargs["batch_id"]
-        found = self._state.beta.vector_stores.file_batches.get(batch_id)
+        found = self._state.vector_stores.file_batches.get(batch_id)
         if not found:
             return httpx.Response(404)
 
@@ -227,7 +227,7 @@ class VectorStoreFileBatchListFilesRoute(
         before = request.url.params.get("before")
         filter = request.url.params.get("filter")
 
-        data = self._state.beta.vector_stores.list_files_for_batch(
+        data = self._state.vector_stores.list_files_for_batch(
             vector_store_id,
             batch_id,
             limit,
@@ -238,7 +238,7 @@ class VectorStoreFileBatchListFilesRoute(
         )
         result_count = len(data)
         total_count = len(
-            self._state.beta.vector_stores.list_files_for_batch(
+            self._state.vector_stores.list_files_for_batch(
                 vector_store_id,
                 batch_id,
             )

--- a/src/openai_responses/_routes/beta/vector_store_files.py
+++ b/src/openai_responses/_routes/beta/vector_store_files.py
@@ -5,8 +5,8 @@ import httpx
 import respx
 
 from openai.pagination import SyncCursorPage
-from openai.types.beta.vector_stores.vector_store_file import VectorStoreFile
-from openai.types.beta.vector_stores.vector_store_file_deleted import (
+from openai.types.vector_stores.vector_store_file import VectorStoreFile
+from openai.types.vector_stores.vector_store_file_deleted import (
     VectorStoreFileDeleted,
 )
 
@@ -50,7 +50,7 @@ class VectorStoreFileCreateRoute(
         self._route = route
 
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
@@ -59,7 +59,7 @@ class VectorStoreFileCreateRoute(
         if not found_file:
             return httpx.Response(404)
 
-        self._state.beta.vector_stores.files.put(model)
+        self._state.vector_stores.files.put(model)
         return httpx.Response(status_code=self._status_code, json=model_dict(model))
 
     @staticmethod
@@ -102,7 +102,7 @@ class VectorStoreFileListRoute(
         self._route = route
 
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
@@ -112,7 +112,7 @@ class VectorStoreFileListRoute(
         before = request.url.params.get("before")
         filter = request.url.params.get("filter")
 
-        data = self._state.beta.vector_stores.files.list(
+        data = self._state.vector_stores.files.list(
             vector_store_id,
             limit,
             order,
@@ -121,7 +121,7 @@ class VectorStoreFileListRoute(
             filter,
         )
         result_count = len(data)
-        total_count = len(self._state.beta.vector_stores.files.list(vector_store_id))
+        total_count = len(self._state.vector_stores.files.list(vector_store_id))
         has_data = bool(result_count)
         has_more = total_count != result_count
         first_id = data[0].id if has_data else None
@@ -162,12 +162,12 @@ class VectorStoreFileRetrieveRoute(
     ) -> httpx.Response:
         self._route = route
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
         file_id = kwargs["file_id"]
-        found = self._state.beta.vector_stores.files.get(file_id)
+        found = self._state.vector_stores.files.get(file_id)
         if not found:
             return httpx.Response(404)
 
@@ -205,16 +205,16 @@ class VectorStoreFileDeleteRoute(
     ) -> httpx.Response:
         self._route = route
         vector_store_id = kwargs["vector_store_id"]
-        found_vector_store = self._state.beta.vector_stores.get(vector_store_id)
+        found_vector_store = self._state.vector_stores.get(vector_store_id)
         if not found_vector_store:
             return httpx.Response(404)
 
         file_id = kwargs["file_id"]
-        found = self._state.beta.vector_stores.files.get(file_id)
+        found = self._state.vector_stores.files.get(file_id)
         if not found:
             return httpx.Response(404)
 
-        deleted = self._state.beta.vector_stores.files.delete(file_id)
+        deleted = self._state.vector_stores.files.delete(file_id)
 
         return httpx.Response(
             status_code=200,

--- a/src/openai_responses/_routes/beta/vector_stores.py
+++ b/src/openai_responses/_routes/beta/vector_stores.py
@@ -6,10 +6,10 @@ import httpx
 import respx
 
 from openai.pagination import SyncCursorPage
-from openai.types.beta.vector_store import VectorStore
-from openai.types.beta.vector_store_create_params import VectorStoreCreateParams
-from openai.types.beta.vector_store_update_params import VectorStoreUpdateParams
-from openai.types.beta.vector_store_deleted import VectorStoreDeleted
+from openai.types.vector_store import VectorStore
+from openai.types.vector_store_create_params import VectorStoreCreateParams
+from openai.types.vector_store_update_params import VectorStoreUpdateParams
+from openai.types.vector_store_deleted import VectorStoreDeleted
 
 from .._base import StatefulRoute
 
@@ -47,7 +47,7 @@ class VectorStoreCreateRoute(StatefulRoute[VectorStore, PartialVectorStore]):
     def _handler(self, request: httpx.Request, route: respx.Route) -> httpx.Response:
         self._route = route
         model = self._build({}, request)
-        self._state.beta.vector_stores.put(model)
+        self._state.vector_stores.put(model)
         content: VectorStoreCreateParams = json_loads(request.content)
         file_ids = content.get("file_ids", [])
         for file_id in file_ids:
@@ -60,7 +60,7 @@ class VectorStoreCreateRoute(StatefulRoute[VectorStore, PartialVectorStore]):
                 create_file_req,
                 extra={"vector_store_id": model.id},
             )
-            self._state.beta.vector_stores.files.put(vector_store_file)
+            self._state.vector_stores.files.put(vector_store_file)
 
         return httpx.Response(status_code=self._status_code, json=model_dict(model))
 
@@ -108,9 +108,9 @@ class VectorStoreListRoute(
         after = request.url.params.get("after")
         before = request.url.params.get("before")
 
-        data = self._state.beta.vector_stores.list(limit, order, after, before)
+        data = self._state.vector_stores.list(limit, order, after, before)
         result_count = len(data)
-        total_count = len(self._state.beta.vector_stores.list())
+        total_count = len(self._state.vector_stores.list())
         has_data = bool(result_count)
         has_more = total_count != result_count
         first_id = data[0].id if has_data else None
@@ -149,7 +149,7 @@ class VectorStoreRetrieveRoute(StatefulRoute[VectorStore, PartialVectorStore]):
     ) -> httpx.Response:
         self._route = route
         vector_store_id = kwargs["vector_store_id"]
-        found = self._state.beta.vector_stores.get(vector_store_id)
+        found = self._state.vector_stores.get(vector_store_id)
         if not found:
             return httpx.Response(404)
 
@@ -179,7 +179,7 @@ class VectorStoreUpdateRoute(StatefulRoute[VectorStore, PartialVectorStore]):
     ) -> httpx.Response:
         self._route = route
         vector_store_id = kwargs["vector_store_id"]
-        found = self._state.beta.vector_stores.get(vector_store_id)
+        found = self._state.vector_stores.get(vector_store_id)
         if not found:
             return httpx.Response(404)
 
@@ -214,7 +214,7 @@ class VectorStoreDeleteRoute(
     ) -> httpx.Response:
         self._route = route
         vector_store_id = kwargs["vector_store_id"]
-        deleted = self._state.beta.vector_stores.delete(vector_store_id)
+        deleted = self._state.vector_stores.delete(vector_store_id)
         return httpx.Response(
             status_code=200,
             json=model_dict(

--- a/src/openai_responses/helpers/builders/vector_store_files.py
+++ b/src/openai_responses/helpers/builders/vector_store_files.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import httpx
-from openai.types.beta.vector_stores.vector_store_file import VectorStoreFile
+from openai.types.vector_stores.vector_store_file import VectorStoreFile
 
 from ._base import _generic_builder
 from ..._routes.beta.vector_store_files import VectorStoreFileCreateRoute

--- a/src/openai_responses/helpers/builders/vector_stores.py
+++ b/src/openai_responses/helpers/builders/vector_stores.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import httpx
-from openai.types.beta.vector_store import VectorStore
+from openai.types.vector_store import VectorStore
 
 from ._base import _generic_builder
 from ..._routes.beta.vector_stores import VectorStoreCreateRoute

--- a/src/openai_responses/stores/state_store.py
+++ b/src/openai_responses/stores/state_store.py
@@ -8,9 +8,9 @@ from openai.types.beta.threads.message import Message
 from openai.types.beta.threads.run import Run
 from openai.types.beta.threads.runs.run_step import RunStep
 
-from openai.types.beta.vector_store import VectorStore
-from openai.types.beta.vector_stores.vector_store_file import VectorStoreFile
-from openai.types.beta.vector_stores.vector_store_file_batch import VectorStoreFileBatch
+from openai.types.vector_store import VectorStore
+from openai.types.vector_stores.vector_store_file import VectorStoreFile
+from openai.types.vector_stores.vector_store_file_batch import VectorStoreFileBatch
 
 from .content_store import ContentStore
 from .._constants import SYSTEM_MODELS
@@ -39,6 +39,7 @@ class StateStore:
     def __init__(self) -> None:
         self.files = FileStore()
         self.models = ModelStore()
+        self.vector_stores = VectorStoreStore()
         self.beta = Beta()
 
     def _blind_put(self, resource: Union[AnyModel, Any]) -> None:
@@ -57,11 +58,11 @@ class StateStore:
         elif isinstance(resource, Model):
             self.models.put(resource)
         elif isinstance(resource, VectorStore):
-            self.beta.vector_stores.put(resource)
+            self.vector_stores.put(resource)
         elif isinstance(resource, VectorStoreFile):
-            self.beta.vector_stores.files.put(resource)
+            self.vector_stores.files.put(resource)
         elif isinstance(resource, VectorStoreFileBatch):
-            self.beta.vector_stores.file_batches.put(resource)
+            self.vector_stores.file_batches.put(resource)
         else:
             raise TypeError(f"Cannot put object of type {type(resource)} in store")
 
@@ -70,7 +71,6 @@ class Beta:
     def __init__(self) -> None:
         self.assistants = AssistantStore()
         self.threads = ThreadStore()
-        self.vector_stores = VectorStoreStore()
 
 
 class BaseStore(Generic[M]):


### PR DESCRIPTION
Closes [#70: OpenAI v1.66.0 Compatibility: openai.types.beta.vector_store Missing](https://github.com/mharrisb1/openai-responses-python/issues/70)
